### PR TITLE
Update JVM library filename on Mac OS X

### DIFF
--- a/configure
+++ b/configure
@@ -24871,7 +24871,7 @@ else
      ;;
    darwin*)
      llnl_cv_lib_jvm_dir=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -exec dirname {} \; 2> /dev/null | head -n 1`
+	-name "JavaVM" -exec dirname {} \; 2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm_dir=`find $javatopdir \
@@ -24911,7 +24911,7 @@ else
      ;;
    darwin*)
      llnl_cv_lib_jvm=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -print  2> /dev/null | head -n 1`
+	-name "JavaVM" -print  2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm=`find $javatopdir  \

--- a/runtime/configure
+++ b/runtime/configure
@@ -24934,7 +24934,7 @@ else
      ;;
    darwin*)
      llnl_cv_lib_jvm_dir=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -exec dirname {} \; 2> /dev/null | head -n 1`
+	-name "JavaVM" -exec dirname {} \; 2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm_dir=`find $javatopdir \
@@ -24974,7 +24974,7 @@ else
      ;;
    darwin*)
      llnl_cv_lib_jvm=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -print  2> /dev/null | head -n 1`
+	-name "JavaVM" -print  2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm=`find $javatopdir  \

--- a/runtime/m4/llnl_prog_javah.m4
+++ b/runtime/m4/llnl_prog_javah.m4
@@ -175,7 +175,7 @@ AC_CACHE_CHECK([for path to libjvm.{a,so} or client/libjvm.{a,so} ],
      ;;
    darwin*)
      llnl_cv_lib_jvm=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -print  2> /dev/null | head -n 1`
+	-name "JavaVM" -print  2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm=`find $javatopdir  \
@@ -215,7 +215,7 @@ AC_CACHE_CHECK([for directory where libjvm.{a,so} or client/libjvm.{a,so} reside
      ;;
    darwin*)
      llnl_cv_lib_jvm_dir=`find $javatopdir -follow \
-	-name "libjvm_compat.*" -exec dirname {} \; 2> /dev/null | head -n 1`
+	-name "JavaVM" -exec dirname {} \; 2> /dev/null | head -n 1`
      ;;
    aix*)
      llnl_cv_lib_jvm_dir=`find $javatopdir \


### PR DESCRIPTION
The configure scripts in this PR look for **libjvm_compat.dylib**, which apparently isn't used any longer on Mac OS X. The new library name is **JavaVM** (no file extension) located in `/System/Library/Frameworks/JavaVM.framework`. I checked that this file exists on Mac OS X 10.9, 10.10, and 10.11.
